### PR TITLE
修复ebay文件引入路径

### DIFF
--- a/docs/zhHans/job-postings/bloomberg/data-management-20250605.md
+++ b/docs/zhHans/job-postings/bloomberg/data-management-20250605.md
@@ -3,6 +3,6 @@ title: data management 20250605
 expired: false
 ---
 
-# 📌 Bloomberg 招聘信息
+# Bloomberg 招聘信息
 
 <JobPostingTable job-posting-json-path="bloomberg/data/data-management-20250605.json" />

--- a/docs/zhHans/job-postings/discover/data-engineer-20250604-2.md
+++ b/docs/zhHans/job-postings/discover/data-engineer-20250604-2.md
@@ -1,5 +1,5 @@
 ---
-title: data engineer-2 20250604
+title: data engineer 20250604
 expired: false
 ---
 

--- a/docs/zhHans/job-postings/ebay/data-analyst-20250610.md
+++ b/docs/zhHans/job-postings/ebay/data-analyst-20250610.md
@@ -5,4 +5,4 @@ expired: false
 
 # eBay 招聘信息
 
-<JobPostingTable job-posting-json-path="amazon/data/data-analyst-20250610.json"/>
+<JobPostingTable job-posting-json-path="ebay/data/data-analyst-20250610.json"/>


### PR DESCRIPTION
## PR Description

由于json文件的引入路径错误，ebay招聘信息无法正常展示

1. 修复ebay招聘信息中的文件夹引入路径
2. 修改标题

## 相关 Issue

<!-- 关联 Issue（例如 `#123`），若无则删除此部分 -->

- 关联 Issue: 

## 变更类型

<!-- 点击创建pr按钮后可以勾选适用的变更类型 -->
<!-- 或使用 [x]的方式勾选 -->

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码结构优化


## 测试

<!-- 描述测试步骤或验证方式 -->

1. 本地运行

    ```shell
    npm run docs:dev
    ```
3. 打开浏览器访问 `http://localhost:5173`

## 注意事项

<!-- 需要 Reviewer 关注的特殊说明 -->