### PR TITLE
修复job compass同步异常

### DIFF
--- a/.github/workflows/pr-merge-sync.yml
+++ b/.github/workflows/pr-merge-sync.yml
@@ -46,4 +46,4 @@ jobs:
             echo "$PR_JSON"
             cd ~/logbook
             export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-            python3 scripts/local-scripts/logbook/add_job_compass_pr_record.py --pr_json "$PR_JSON"
+            python3.13 scripts/local-scripts/logbook/add_job_compass_pr_record.py --pr_json "$PR_JSON"


### PR DESCRIPTION
## PR Description

修复job compass同步异常。报错是在CI/CD流水线里发生的，并非logbook项目中的脚本错误。原因是job compass项目中的github workflow在执行任务时使用了python3命令，并非指明具体的3.13版本，因此GitHub Actions 的运行环境默认python3指向了3.8。

## 相关 Issue

<!-- 关联 Issue（例如 `#123`），若无则删除此部分 -->

- 关联 Issue: 

## 变更类型

<!-- 点击创建pr按钮后可以勾选适用的变更类型 -->
<!-- 或使用 [x]的方式勾选 -->

- [ ] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码结构优化


## 测试

<!-- 描述测试步骤或验证方式 -->

1. 本地运行

    ```shell
    npm run docs:dev
    ```
2. 打开浏览器访问 `http://localhost:5173`

## 注意事项

<!-- 需要 Reviewer 关注的特殊说明 -->