### PR TITLE
脚本配置python环境

### DIFF
--- a/.github/workflows/pr-merge-sync.yml
+++ b/.github/workflows/pr-merge-sync.yml
@@ -44,7 +44,10 @@ jobs:
           script: |
             echo "接收到的 PR JSON:"
             echo "$PR_JSON"
+            export PYENV_ROOT="$HOME/.pyenv"
+            export PATH="$PYENV_ROOT/bin:$PATH"
+            eval "$(pyenv init -)"
             which python3 && python3 --version
             cd ~/logbook
             export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-            python3.13 scripts/local-scripts/logbook/add_job_compass_pr_record.py --pr_json "$PR_JSON"
+            python3 scripts/local-scripts/logbook/add_job_compass_pr_record.py --pr_json "$PR_JSON"


### PR DESCRIPTION
## PR Description
通过which命令的输出发现脚本所使用的python路径为`/usr/bin/python3 Python 3.8.10`，而本地通过ssh连接远程服务器后所使用的是`/home/atmBot/.pyenv/shims/python3`

cc结论：SSH action 运行的是一个非交互式 shell，因此 pyenv 从未被初始化，实际使用的是 /usr/bin/python3（3.8.10）。

修复方式：在运行脚本之前先加载`pyenv`

## 相关 Issue

<!-- 关联 Issue（例如 `#123`），若无则删除此部分 -->

- 关联 Issue: 

## 变更类型

<!-- 点击创建pr按钮后可以勾选适用的变更类型 -->
<!-- 或使用 [x]的方式勾选 -->

- [ ] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码结构优化


## 测试

<!-- 描述测试步骤或验证方式 -->

1. 本地运行

    ```shell
    npm run docs:dev
    ```
2. 打开浏览器访问 `http://localhost:5173`

## 注意事项

<!-- 需要 Reviewer 关注的特殊说明 -->