### PR TITLE
修复pr数据记录脚本

### DIFF
--- a/.github/workflows/pr-merge-sync.yml
+++ b/.github/workflows/pr-merge-sync.yml
@@ -50,4 +50,4 @@ jobs:
             which python3 && python3 --version
             cd ~/json-data-source
             export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-            python3 scripts/local-scripts/logbook/add_job_compass_pr_record.py --pr_json "$PR_JSON"
+            python3 scripts/local-scripts/job-compass/add_job_compass_pr_record.py --pr_json "$PR_JSON"


### PR DESCRIPTION
## PR Description

`json-data-source`仓库中`add_job_compass_pr_record.py`脚本路径发生变更，进而导致 PR merge 后的 GitHub Actions 报错

修复方式：根据json-data-source仓库中的改变修改调用脚本的路径

## 相关 Issue

<!-- 关联 Issue（例如 `#123`），若无则删除此部分 -->

- 关联 Issue: 

## 变更类型

<!-- 点击创建pr按钮后可以勾选适用的变更类型 -->
<!-- 或使用 [x]的方式勾选 -->

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 代码结构优化


## 测试

<!-- 描述测试步骤或验证方式 -->

1. 本地运行

    ```shell
    npm run docs:dev
    ```
2. 打开浏览器访问 `http://localhost:5173`

## 注意事项

<!-- 需要 Reviewer 关注的特殊说明 -->