### PR TITLE
新增 notify-logbook-pr-review 工作流：PR review 后通知 logbook 记工时

### DIFF
--- a/.github/workflows/notify-logbook-pr-review.yml
+++ b/.github/workflows/notify-logbook-pr-review.yml
@@ -1,0 +1,40 @@
+name: notify-logbook-pr-review
+
+# 每当有人提交一次 PR review，就通知 logbook 仓库建一条工时记录 issue。
+# 实际的建 issue 逻辑和模板都在 logbook 侧（.github/workflows/create-pr-review-issue.yml），
+# 这里只负责发 repository_dispatch。
+#
+# 跨仓库触发用不了 GITHUB_TOKEN，需要在本仓库配一个对 logbook 有 repo 权限的 PAT：
+# secrets.LOGBOOK_DISPATCH_TOKEN。
+#
+# 同一个 PR 被 review 多轮会重复触发，logbook 侧按 PR 链接去重，不会攒出多个 issue。
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  dispatch:
+    # 自己 review 自己的 PR 不记工时
+    if: github.event.review.user.login != github.event.pull_request.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to logbook
+        env:
+          GH_TOKEN: ${{ secrets.LOGBOOK_DISPATCH_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          REVIEWER: ${{ github.event.review.user.login }}
+        run: |
+          # 贡献者写成「GitHub 用户名（姓名）」，姓名未公开时只留用户名
+          NAME=$(gh api "users/$AUTHOR" --jq '.name // ""')
+          CONTRIBUTOR="$AUTHOR"
+          if [ -n "$NAME" ]; then
+            CONTRIBUTOR="$AUTHOR（$NAME）"
+          fi
+
+          gh api repos/atomeocean/logbook/dispatches \
+            -f event_type=job-compass-pr-review \
+            -f "client_payload[pr_url]=$PR_URL" \
+            -f "client_payload[contributor]=$CONTRIBUTOR" \
+            -f "client_payload[assignee]=$REVIEWER" \
+            -f "client_payload[hours]="


### PR DESCRIPTION
## 做什么

每当本仓库有人提交一次 PR review，就向 logbook 发一个 `repository_dispatch`，由 logbook 侧建一条工时记录 issue。

本仓库只负责**触发**，建 issue 的逻辑和模板都在 logbook 的 `.github/workflows/create-pr-review-issue.yml` —— 那边已经在监听 `job-compass-pr-review` 事件类型了，这个 PR 补的是缺的另一半。

## 行为

- **自己 review 自己的 PR 不记工时**（`review.user != pull_request.user`）
- 贡献者字段写成「GitHub 用户名（姓名）」，姓名未公开时只留用户名
- 同一个 PR 被 review 多轮会重复触发，logbook 侧按 PR 链接去重，不会攒出多个 issue

## 合并前必须做的一件事

需要在本仓库 Settings → Secrets and variables → Actions 配置 **`LOGBOOK_DISPATCH_TOKEN`**：跨仓库触发用不了内置的 `GITHUB_TOKEN`，需要一个对 `atomeocean/logbook` 有 repo 权限的 PAT。没配的话工作流会在 dispatch 这一步失败。

## 说明

这个文件此前一直是本地未提交状态，本 PR 只是把它原样纳入版本控制，内容未作改动。工作流本身**尚未在真实 PR review 上跑过**——需要合并且配好 secret 之后才能验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
